### PR TITLE
User unable to reopen issue once closed by bot

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ module.exports = function(robot) {
     const boilerplate = new Boilerplate();
     const title = context.payload.issue.title;
     const body = context.payload.issue.body;
-    const cannedReply = "Thanks for your issue report, but unfortunately you haven't told us what the problem was. Please edit the title and body of your issue to describe your problem. Be sure to delete the boilerplate. Once you've done this, you may reopen the issue.";
+    const cannedReply = "Thanks for your issue report, but unfortunately you haven't told us what the problem was. Please open a new issue describing your problem.";
 
     if (boilerplate.hasDefaultTitle(title) || boilerplate.hasDefaultBody(body)) {
       return context.github.issues.edit(context.issue({state: 'closed'})).then(() => {


### PR DESCRIPTION
According to this: https://stackoverflow.com/a/21333938/3250984
if an issue has been closed by a repo collaborator it cannot be reopened
by the person who originally opened the issue. I assume the bot counts
as a repo collaborator. This commit changes the canned reply to reflect
this.

Fixes #2