### PR TITLE
Allow boilerplate body text within updated issue

### DIFF
--- a/boilerplate.js
+++ b/boilerplate.js
@@ -1,6 +1,6 @@
 module.exports = class Boilerplate {
   hasDefaultBody(text) {
-    const body = /Change the title above to describe your issue and add your feedback here, including code if necessary/;
+    const body = /Change the title above to describe your issue and add your feedback here, including code if necessary\s*$/;
     return body.test(text);
   }
 

--- a/boilerplate.js
+++ b/boilerplate.js
@@ -1,5 +1,5 @@
 module.exports = class Boilerplate {
-  hasDefaultBody(text) {
+  hasOnlyDefaultBody(text) {
     const body = /Change the title above to describe your issue and add your feedback here, including code if necessary\s*$/;
     return body.test(text);
   }

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ module.exports = function(robot) {
     const body = context.payload.issue.body;
     const cannedReply = "Thanks for your issue report, but unfortunately you haven't told us what the problem was. Please edit the title and body of your issue to describe your problem. Be sure to delete the boilerplate. Once you've done this, you may reopen the issue.";
 
-    if (boilerplate.hasDefaultTitle(title) || boilerplate.hasDefaultBody(body)) {
+    if (boilerplate.hasDefaultTitle(title) || boilerplate.hasOnlyDefaultBody(body)) {
       return context.github.issues.edit(context.issue({state: 'closed'})).then(() => {
         return context.github.issues.createComment(context.issue({body: cannedReply}));
       });

--- a/test.js
+++ b/test.js
@@ -23,4 +23,14 @@ describe('bot behavior', function () {
     const text = "Something else"
     expect(boilerplate.hasDefaultTitle(text)).toBe(false);
   })
+
+  it('does not match on custom body text containing placeholder body', function() {
+    const text = "Context: http://example.com\r\n\r\nChange the title above to describe your issue and add your feedback here, including code if necessary\r\n\r\nSomething else"
+    expect(boilerplate.hasDefaultBody(text)).toBe(false);
+  })
+
+  it('recognizes issues with placeholder body including added whitespace', function () {
+    const text = "Context: http://example.com\r\n\r\nChange the title above to describe your issue and add your feedback here, including code if necessary\r\n\r\n"
+    expect(boilerplate.hasDefaultBody(text)).toBe(true);
+  })
 })

--- a/test.js
+++ b/test.js
@@ -6,12 +6,12 @@ describe('bot behavior', function () {
 
   it('recognizes issues with placeholder body', function () {
     const text = "Context: http://example.com\r\n\r\nChange the title above to describe your issue and add your feedback here, including code if necessary"
-    expect(boilerplate.hasDefaultBody(text)).toBe(true);
+    expect(boilerplate.hasOnlyDefaultBody(text)).toBe(true);
   })
 
   it('does not match on custom body text', function() {
     const text = "Something else"
-    expect(boilerplate.hasDefaultBody(text)).toBe(false);
+    expect(boilerplate.hasOnlyDefaultBody(text)).toBe(false);
   })
 
   it('recognizes issues with placeholder title', function () {
@@ -26,7 +26,7 @@ describe('bot behavior', function () {
 
   it('does not match on custom body text containing placeholder body', function() {
     const text = "Context: http://example.com\r\n\r\nChange the title above to describe your issue and add your feedback here, including code if necessary\r\n\r\nSomething else"
-    expect(boilerplate.hasDefaultBody(text)).toBe(false);
+    expect(boilerplate.hasOnlyDefaultBody(text)).toBe(false);
   })
 
   it('recognizes issues with placeholder body including added whitespace', function () {


### PR DESCRIPTION
If someone has changed the boilerplate title, but left in the
boilerplate body, adding their issue below it, then their issue will be
closed even though it may be a valid issue. With this commit an issue
whose body ends with the boilerplate text (including any trailing
whitespace or newlines to avoid someone hitting enter after the
boilerplate constituting an issue) will be closed, but an issue
that contains text after the boilerplate text will not.

Fixes #4

Also changes function name to reflect above change.